### PR TITLE
update composer.json for 'add composer serve-api'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
             "phpcbf src tests"
         ],
         "serve": "php -dzend_extension=xdebug.so -S 127.0.0.1:8080 -t public",
+        "serve-api": "php -dzend_extension=xdebug.so -S 127.0.0.1:8081 bin/app.php",
         "app": "php bin/app.php",
         "page": "php bin/page.php",
         "deploy-prod": "cd bin/deploy; php deployer.phar deploy prod",


### PR DESCRIPTION
READMEにありました、serve-apiがなくなっていましたので、bin/app.phpが代替になると思い追加しました。

ただ、TODOSの表示でエラーがでます。
jsonSchemaで、TODOはtodo.jsonの配列を指定しているのですが、
生成されるデータが配列＋halのlinkなのでオブジェクトという判定になってエラーになるようです。
こちらはどのように修正をしてよいかわかりませんでした。

```
bash-5.0# curl -i  http://127.0.0.1:8081/todos
HTTP/1.1 500 Internal Server Error
Host: 127.0.0.1:8081
Date: Wed, 13 Nov 2019 03:21:01 GMT
Connection: close
X-Powered-By: PHP/7.3.9
content-type: application/vnd.error+json

{
    "message": "Internal Server Error",
    "logref": "25689786",
    "request": "get app://self/todos",
    "exceptions": "BEAR\\Resource\\Exception\\JsonSchemaException([] Object value found, but an array is required; by /app/var/json_schema/todos.json)",
    "file": "/app/vendor/bear/resource/src/JsonSchema/Interceptor/JsonSchemaInterceptor.php(157)"
}
```
app/Todos.phpのonGetのJsonSchemaのバリデーションを外した場合は、以下のように返ってきました。

```
bash-5.0# curl -i  http://127.0.0.1:8081/todos
HTTP/1.1 200 OK
Host: 127.0.0.1:8081
Date: Wed, 13 Nov 2019 03:21:41 GMT
Connection: close
X-Powered-By: PHP/7.3.9
Content-type: text/html; charset=UTF-8

{
    "0": {
        "id": "1",
        "title": "walking",
        "status": "1",
        "created": "",
        "updated": ""
    },
    "1": {
        "id": "2",
        "title": "think",
        "status": "1",
        "created": "",
        "updated": ""
    },
    "2": {
        "id": "3",
        "title": "walking",
        "status": "1",
        "created": "",
        "updated": ""
    },
    "3": {
        "id": "4",
        "title": "think",
        "status": "1",
        "created": "",
        "updated": ""
    },
    "_links": {
        "self": {
            "href": "/todos"
        }
    }
}
```
